### PR TITLE
Improve banner spacing and border radius

### DIFF
--- a/css/banner.css
+++ b/css/banner.css
@@ -2,6 +2,7 @@
 	position: relative;
 	top: var(--announcementbanner-offset, 56px);
 	margin-bottom: 8px;
+	padding: 0 var(--body-container-margin);
 	display: flex;
 	flex-direction: column;
 	gap: 12px;
@@ -17,7 +18,7 @@
 	gap: 12px;
 	padding: 12px 18px;
 	font-weight: 600;
-	border-radius: 10px;
+	border-radius: var(--body-container-radius);
 	border: 1px solid transparent;
 	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
 	margin: 0;


### PR DESCRIPTION
Hey 👋 Thanks for making this useful app! Everything works great but the announcements pressed against the side of the screen with a border radius really triggers me 😅

My suggestion is to add the same horizontal space as the main content by using its CSS variable. Since this space and the border radius disappear when the screen is narrow, I replaced your radius value by the main content variable to match this behavior (it also increases the radius to 16px).

Here is what it looks like (desktop and small screen):
<img width="3940" height="323" alt="Screenshot 2026-03-15 at 17-24-56 Tous les fichiers - Fichiers - Serveur" src="https://github.com/user-attachments/assets/05e2b17d-efcd-4b89-9dc7-79d5f3c8035b" />

<img width="1620" height="325" alt="Screenshot 2026-03-15 at 17-25-07 Tous les fichiers - Fichiers - Serveur" src="https://github.com/user-attachments/assets/ac1d3aba-9501-4856-a5d1-c3c67355ef13" />

I hope you will like it!